### PR TITLE
Cleanup + Wasta-Offline

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,9 +3,11 @@ Section: misc
 Priority: optional
 Maintainer: Chris Hubbard <chris_habbard@sil.org>
 Build-Depends: debhelper (>= 9.0.0)
+Standards-Version: 3.9.5
 
 Package: android-sdk-installer
 Architecture: i386
+Pre-Depends: ${misc:Pre-Depends}, debconf (>= 0.5) | debconf-2.0
 Depends: update-notifier-common (>= 0.119ubuntu2), ${misc:Depends},
  libncurses5, libstdc++6, zlib1g, unzip
 Description: Installer for the Android SDK

--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,4 @@ override_dh_auto_install:
 	done < zipfiles.sha256sums > debian/tmp/usr/share/package-data-downloads/android-sdk-installer
 	echo "Script: /usr/lib/android-sdk-installer/install-android-sdk" >> debian/tmp/usr/share/package-data-downloads/android-sdk-installer
 	echo "Should-Download: android-sdk-installer/accepted-android-sdk-eula" >> debian/tmp/usr/share/package-data-downloads/android-sdk-installer
+	echo "Offline-Download-Dir: android-sdk-install/dldir" >> debian/tmp/usr/share/package-data-downloads/android-sdk-installer

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,2 @@
+android-sdk-installer source: not-using-po-debconf
+android-sdk-installer source: untranslatable-debconf-templates


### PR DESCRIPTION
* clean up a few lintian errors/warnings
* add Offline-Download-Dir: <debconf-variable-name> so that Wasta-Offline could download the files and provide preseed.cfg when files are synced.